### PR TITLE
Here's a few more changes for the SELinux support on CentOS.

### DIFF
--- a/rpm/config/apache-passenger.conf.in
+++ b/rpm/config/apache-passenger.conf.in
@@ -2,7 +2,7 @@ LoadModule passenger_module modules/mod_passenger.so
 <IfModule mod_passenger.c>
    PassengerRoot %ROOT
    PassengerRuby %RUBY
-   PassengerTempDir /var/run/passenger
+   PassengerTempDir /var/run/rubygem-passenger
 </IfModule>
 
 # Deploying a Ruby on Rails application: an example

--- a/rpm/config/rubygem-passenger.fc.in
+++ b/rpm/config/rubygem-passenger.fc.in
@@ -2,9 +2,9 @@
 %GEMDIR%/agents/Passenger.*	system_u:object_r:httpd_exec_t:s0
 %VAR%/log/passenger-analytics	system_u:object_r:httpd_log_t:s0
 # This dir is created by the parent, and needs to be read by the child. 
-# Keep it simple and allow the helper domain to do what it needs
-# instead.
-# %VAR%/run/passenger(/.*)?	system_u:object_r:httpd_passenger_helper_t:s0
+# Keep it with httpd_var_run_t perms, and allow that in .te
+%VAR%/run/rubygem-passenger	system_u:object_r:httpd_var_run_t:s0
+%VAR%/run/rubygem-passenger/(passenger.*)(/.*)?	system_u:object_r:httpd_var_run_t:s0
 # EPEL's nginx package doesn't have any SELlinux support??
 /usr/sbin/nginx.passenger	system_u:object_r:httpd_exec_t:s0
 %VAR%/log/nginx(/.*)?		system_u:object_r:httpd_log_t:s0

--- a/rpm/config/rubygem-passenger.te
+++ b/rpm/config/rubygem-passenger.te
@@ -1,4 +1,4 @@
-policy_module(rubygem_passenger, 1.5)
+policy_module(rubygem_passenger, 1.5.5)
 
 require {
   role system_r;
@@ -18,6 +18,10 @@ domain_auto_trans(httpd_t,httpd_passenger_helper_exec_t,httpd_passenger_helper_t
 # For ps 
 kernel_list_proc(httpd_passenger_helper_t)
 kernel_search_proc(httpd_passenger_helper_t)
+kernel_read_system_state(httpd_passenger_helper_t)
+domain_dontaudit_search_all_domains_state(httpd_passenger_helper_t)
+domain_dontaudit_read_all_domains_state(httpd_passenger_helper_t)
+
 # - these don't work because the process files & dirs all have their own domains as types
 # kernel_getattr_proc(httpd_passenger_helper_t)
 # kernel_getattr_proc_files(httpd_passenger_helper_t)

--- a/rpm/passenger.spec
+++ b/rpm/passenger.spec
@@ -10,10 +10,11 @@
 
 %define gemname passenger
 %if %{?passenger_version:0}%{?!passenger_version:1}
+  # From Passenger Source
   %define passenger_version 3.0.11
 %endif
 %if %{?passenger_release:0}%{?!passenger_release:1}
-  %define passenger_release 1%{?dist}
+  %define passenger_release 8%{?dist}
 %endif
 %define passenger_epoch 1
 
@@ -520,7 +521,7 @@ mkdir -p %{buildroot}/%{httpd_confdir}
 mkdir -p %{buildroot}/%{_var}/log/passenger-analytics
 
 # The %ghost must be created?
-mkdir -p %{buildroot}/%{_var}/run/passenger
+mkdir -p %{buildroot}/%{_var}/run/rubygem-passenger
 
 # I should probably figure out how to get these into the gem
 cp -ra agents %{buildroot}/%{geminstdir}
@@ -689,7 +690,7 @@ rm -rf %{buildroot}
 %{geminstdir}/agents/PassengerWatchdog
 %{sharedir}/selinux/packages/%{name}/%{name}.pp
 %{_var}/log/passenger-analytics
-%ghost %dir %{_var}/run/passenger
+%ghost %dir %{_var}/run/rubygem-passenger
 
 %files -n passenger-standalone
 %doc doc/Users\ guide\ Standalone.html
@@ -722,6 +723,10 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Wed Dec 21 2011 Darrell Fuhriman <darrell@renewfund.com> - 1:3.0.11-7
+- Relocated PassengerTempDir to avoid conflicts with system selinux-policy
+- Reduced the amount of unecessary log noise on {CentOS/RHEL}{5,6}
+
 * Mon Nov 28 2011 Erik Ogan <erik@steathymonkeys.com> - 1:3.0.11-1
 - Bump version to 3.0.11
 


### PR DESCRIPTION
 I've tested these on CentOS 5/6. I was still getting lots of unnecessary log entries, which this seems to have taken care of.

I ended up moving PassengerTempDir into /var/run/rubygem-passenger, because I was getting lots of incompatible behavior from the system installed policy. Specifically, /var/run/passenger was defined as type passenger_t, and I could not convince the system to let me override that, so I just quit fighting it and moved it. I haven't found any other conflicts with the selinux-policy defined passenger config.

I suspect there is still some stuff in there that can be removed, but I haven't yet tackled weeding it out. And sorry for the big version jumps – I was doing lots of testing to make sure the RPMs were building and installing cleanly.
